### PR TITLE
Remove turbolinks so select2 on tag entry works

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,8 +10,8 @@ gem 'uglifier', '>= 1.3.0'
 gem 'coffee-rails', '~> 4.0.0'
 
 gem 'jquery-rails'
-gem 'turbolinks'
-gem 'jquery-turbolinks'
+#gem 'turbolinks'
+#gem 'jquery-turbolinks'
 gem 'bootstrap-sass', '~> 3.3.3'
 
 # Authentication

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,9 +140,6 @@ GEM
     jquery-rails (3.1.2)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
-    jquery-turbolinks (2.1.0)
-      railties (>= 3.1.0)
-      turbolinks
     jquery-ui-rails (5.0.2)
       railties (>= 3.2.16)
     json (1.8.2)
@@ -305,8 +302,6 @@ GEM
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (1.4.1)
-    turbolinks (2.5.1)
-      coffee-rails
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     uglifier (2.5.3)
@@ -338,7 +333,6 @@ DEPENDENCIES
   fuubar
   gravatar_image_tag
   jquery-rails
-  jquery-turbolinks
   letter_opener
   mini_magick
   minitest
@@ -364,7 +358,6 @@ DEPENDENCIES
   spring
   spring-commands-rspec
   sqlite3
-  turbolinks
   uglifier (>= 1.3.0)
 
 BUNDLED WITH

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,7 +12,6 @@
 //
 //= require jquery
 //= require jquery_ujs
-//= require turbolinks
 //= require bootstrap-sprockets
 //= require owl.carousel
 //= require select2

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,8 +31,8 @@
 	<link rel="alternate" type="application/rss+xml" title="Startup Wichita - People" href="/people/feed?format=rss">
 	<link rel="alternate" type="application/rss+xml" title="Startup Wichita - Resources" href="/resources/feed?format=rss">
 
-    <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
-    <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
+    <%= stylesheet_link_tag    'application', media: 'all' %>
+    <%= javascript_include_tag 'application' %>
     <%= csrf_meta_tags %>
   </head>
   <body>


### PR DESCRIPTION
It was failing to initialize because the JS that runs on those pages was not
being executed for the new field on the screen since it was loaded in with
turbolinks. I think the site performance is good enough that we can remove it
without much worry. This would have to be done in the future if we did any
sufficiently complex JS anyways.

If we _really_ want to, we can add them back in later.

Closes #25
