### PR TITLE
Close #24 - Filtering people index

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -6,8 +6,8 @@ class PeopleController < InheritedResources::Base
 
   def index
     if params[:tag]
-      @featured_people = Person.where(featured: true).tagged_with(params[:tag])
-      @people = Person.where(featured: false).tagged_with(params[:tag])
+      @featured_people = Person.tagged_with(params[:tag]).where(featured: true).uniq
+      @people = Person.tagged_with(params[:tag]).where(featured: false).uniq
     else
       @featured_people = Person.where(featured: true)
       @people = Person.where(featured: false)

--- a/app/views/people/index.html.erb
+++ b/app/views/people/index.html.erb
@@ -49,7 +49,7 @@
   </div>
   </div>
 
-  <% unless @people.blank? %>
+  <% unless @people.blank? && @featured_people.blank? %>
     <% if @featured_people.size > 0 %>
       <hr/>
 


### PR DESCRIPTION
The failure was due to the broken `unless` in the people index view. It was
assuming there were no results if the _non-featured_ person collection was
empty. If the result only included `featured` people, it showed the "No people"
message.

Another issue was that if a person had the same tag on different attributes
(skills and roles, for example) they would be included twice. So we're filtering
out to only show unique results now.
