### PR TITLE
Email links should include `www`

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -61,7 +61,7 @@ Rails.application.configure do
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
 
-  config.action_mailer.default_url_options = { host: 'http://startupwichita.com', port: 80 }
+  config.action_mailer.default_url_options = { host: 'http://www.startupwichita.com', port: 80 }
 
   config.action_mailer.smtp_settings = {
     :address => "smtp.sendgrid.net",


### PR DESCRIPTION
This is because of something stupid with Google Domains that doesn't let us put
a blank subdomain record for a CNAME. Weird.
