### PR TITLE
Add Person Profile Completeness Score

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -6,12 +6,13 @@ class PeopleController < InheritedResources::Base
 
   def index
     if params[:tag]
-      @featured_people = Person.tagged_with(params[:tag]).where(featured: true).uniq
-      @people = Person.tagged_with(params[:tag]).where(featured: false).uniq
+      @featured_people = Person.tagged_with(params[:tag]).uniq
+      @people = Person.tagged_with(params[:tag]).uniq
     else
-      @featured_people = Person.where(featured: true)
-      @people = Person.where(featured: false)
+      @featured_people = Person.all
+      @people = Person.all
     end
+
     respond_to do |format|
       format.html
       format.csv {render text: @people.to_csv}

--- a/db/migrate/20160928005200_add_profile_score_to_people.rb
+++ b/db/migrate/20160928005200_add_profile_score_to_people.rb
@@ -1,0 +1,7 @@
+class AddProfileScoreToPeople < ActiveRecord::Migration
+  def change
+    add_column(:people, :profile_score, :integer, default: 0, null: false)
+
+    add_index(:people, :profile_score)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150927184023) do
+ActiveRecord::Schema.define(version: 20160928005200) do
 
   create_table "events", force: true do |t|
     t.datetime "starts_at"
@@ -55,8 +55,10 @@ ActiveRecord::Schema.define(version: 20150927184023) do
     t.boolean  "allow_contact",       default: true
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.integer  "profile_score",       default: 0,     null: false
   end
 
+  add_index "people", ["profile_score"], name: "index_people_on_profile_score"
   add_index "people", ["slug"], name: "index_people_on_slug", unique: true
   add_index "people", ["user_id"], name: "index_people_on_user_id"
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,24 +1,15 @@
-FactoryGirl.define do  factory :person_email do
-    person nil
-recipient_email "MyString"
-sender_email "MyString"
-message "MyText"
-sender_phone "MyString"
+FactoryGirl.define do
+  factory :person_email do
+    person
+    recipient_email 'MyString'
+    sender_name 'Sender'
+    sender_email 'MyString'
+    message 'MyText'
+    sender_phone 'MyString'
   end
+
   factory :person_role do
-    name "MyString"
-  end
-  factory :person do
-    user nil
-first_name "MyString"
-last_name "MyString"
-email "MyString"
-website "MyString"
-company_name "MyString"
-title "MyString"
-twitter_username "MyString"
-bio "MyText"
-#avatar ""
+    name 'MyString'
   end
 
   factory :user do

--- a/spec/factories/person.rb
+++ b/spec/factories/person.rb
@@ -1,0 +1,16 @@
+FactoryGirl.define do
+  factory :person do
+    user
+    first_name 'Charles'
+    last_name 'Lee'
+    email 'charles.lee@example.com'
+    phone '999-999-9999'
+    website 'charleschanlee@example.com'
+    company_name 'Charlie Co.'
+    title 'Software Engineer'
+    twitter_username 'ExampleChar'
+    bio 'Software engineer participating in Hackoberfest!'
+    avatar_file_name 'example_avatar.jpg'
+    allow_contact true
+  end
+end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -1,5 +1,35 @@
-require 'rails_helper'
+RSpec.describe Person do
+  let(:existing_person) { create(:person) }
 
-RSpec.describe Person, :type => :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe '#update_profile_score' do
+    it 'updates the score after create' do
+      new_person = Person.create(first_name: 'FirstName', last_name: 'LastName')
+
+      expect(new_person.profile_score).to eq(15)
+    end
+
+    it 'updates the score after an update' do
+      old_score = existing_person.profile_score
+      existing_person.update_attributes(avatar_file_name: nil)
+
+      expect(existing_person.profile_score).to eq(
+        old_score - described_class::SCORING_GUIDE[:avatar_file_name]
+      )
+    end
+  end
+
+  describe '#default_scope' do
+    let!(:missing_email_phone) { create(:person, email: nil, phone: nil) }
+    let!(:first_featured_person) { create(:person, featured: true) }
+    let!(:second_featured_person) { create(:person, featured: true) }
+
+    it 'orders by profile score followed by updated_at' do
+      expect(Person.first).to eq(second_featured_person)
+      expect(Person.last).to eq(missing_email_phone)
+
+      # Emulate an 'update'
+      first_featured_person.touch
+      expect(Person.first).to eq(first_featured_person)
+    end
+  end
 end


### PR DESCRIPTION
Resolves https://github.com/StartupWichita/startupwichita.com/issues/43

Changes:
1. Adds `profile_score` col to `People`. Score is updated on `update` or `create`
2. Updated `People#index` to use profile scores. We're ordering by score then by `updated_at`. 
3. Added a factories directory as there wasn't one.
4. Added related specs.

Decided to create a column instead of calculating these scores on the fly which should improve performance when rendering the index. 
Created a hash to calculate the score based on personal preference but this should be looked more into by a mod that knows the community better and has a better sense of what deserves to have a larger impact on scoring.
