### PR TITLE
Rake task to autoload events from meetup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@
 /public/system/*/*
 /config/initializers/devise.rb
 .DS_Store
+.env

--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,8 @@ gem 'friendly_id', '~> 5.1.0' # Note: You MUST use 5.0.0 or greater for Rails 4.
 gem 'bootstrap3-datetimepicker-rails', '~> 4.14.30'
 gem 'configatron'
 
+gem 'meetup_client'
+
 gem 'momentjs-rails', '>= 2.9.0'
 
 gem 'gravatar_image_tag'
@@ -42,6 +44,8 @@ gem 'mini_magick'
 group :development, :test do
   gem 'spring'
   gem 'sqlite3'
+
+  gem 'dotenv-rails'
 
   gem 'annotate'
   gem 'pry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,6 +106,10 @@ GEM
       thread_safe (~> 0.1)
       warden (~> 1.2.3)
     diff-lcs (1.2.5)
+    dotenv (2.1.1)
+    dotenv-rails (2.1.1)
+      dotenv (= 2.1.1)
+      railties (>= 4.0, < 5.1)
     erubis (2.7.0)
     execjs (2.2.2)
     factory_girl (4.5.0)
@@ -155,6 +159,7 @@ GEM
       launchy (~> 2.2)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
+    meetup_client (0.1.0)
     method_source (0.8.2)
     mime-types (2.4.3)
     mini_magick (4.0.4)
@@ -333,6 +338,7 @@ DEPENDENCIES
   configatron
   database_cleaner
   devise
+  dotenv-rails
   factory_girl_rails
   formulaic
   friendly_id (~> 5.1.0)
@@ -340,6 +346,7 @@ DEPENDENCIES
   gravatar_image_tag
   jquery-rails
   letter_opener
+  meetup_client
   mini_magick
   minitest
   momentjs-rails (>= 2.9.0)
@@ -368,5 +375,8 @@ DEPENDENCIES
   sqlite3
   uglifier (>= 1.3.0)
 
+RUBY VERSION
+   ruby 2.2.0p0
+
 BUNDLED WITH
-   1.13.1
+   1.13.2

--- a/config/initializers/meetup_client.rb
+++ b/config/initializers/meetup_client.rb
@@ -1,0 +1,5 @@
+require 'meetup_client'
+
+MeetupClient.configure do |config|
+  config.api_key = ENV['MEETUP_API_KEY']
+end

--- a/lib/tasks/pull_events_from_meetup.rake
+++ b/lib/tasks/pull_events_from_meetup.rake
@@ -1,0 +1,88 @@
+namespace :events do
+  task :meetup => :environment do
+    require 'meetup_client'
+
+    # -------
+    # https://github.com/cranieri/meetup_client
+    # -------
+
+    def create_new_event(event)
+      record = Event.create(
+        title: event['name'],
+        content: event['description'],
+        url: event['event_url'],
+        starts_at: Time.at(event['time']/1000),
+        ends_at: get_ends_at(event['time'], event['duration']),
+        address: format_address(event['venue']),
+        user_id: ENV['RAKE_EVENTS_OWNER_ID'])
+
+      if record.persisted?
+        puts "Created! -- #{record.title} (#{record.id})"
+      else
+        puts "Error creating! -- #{record.errors.full_messages.to_sentence}"
+      end
+    end
+
+    def update_existing_event(event)
+      record = Event.where(url: event['event_url']).first
+      return if record.user_id && record.user_id != ENV['RAKE_EVENTS_OWNER_ID']
+
+      record.title = event['name']
+      record.content = event['description']
+      record.url = event['event_url']
+      record.starts_at = Time.at(event['time']/1000)
+      record.ends_at = get_ends_at(event['time'], event['duration'])
+      record.address = format_address(event['venue'])
+      record.user_id = ENV['RAKE_EVENTS_OWNER_ID']
+
+      if record.save
+        puts "Updated! -- #{record.title} (#{record.id})"
+      else
+        puts "Error updating! -- (#{record.id}) -- #{record.errors.full_messages.to_sentence}"
+      end
+    end
+
+    def get_and_load_events(event_sources)
+      meetup_api = MeetupApi.new
+      two_months_from_now = (Time.now + (60*24*60*60)).to_i * 1000
+
+      event_sources.each do |source|
+        response = meetup_api.events(
+          group_urlname: source,
+          status: 'upcoming'
+        )
+
+        response['results'].each do |event|
+          next if event['time'] > two_months_from_now
+          event_exists(event) ? update_existing_event(event) : create_new_event(event)
+        end
+      end
+    end
+
+    def event_exists(event)
+      Event.where(url: event['event_url']).any?
+    end
+
+    def format_address(venue)
+      return "TBD" if !venue
+
+      result = ""
+      result << "#{venue['name']}, " unless venue['name'].empty?
+      result << "#{venue['address_1']}, "
+      result << "#{venue['city']}, "
+      result << "#{venue['state']}"
+      result << " #{venue['zip']}"
+      result
+    end
+
+    def get_ends_at(time, duration)
+      duration ? Time.at((time + duration)/1000) : Time.at(time)
+    end
+
+    # --------------------
+    # DO THINGS!
+    # --------------------
+    event_sources = ENV['MEETUP_EVENT_SOURCES'].split(',')
+    get_and_load_events(event_sources)
+  end
+end


### PR DESCRIPTION
Adds `rake events:meetup` to tasks. Relies on two ENV vars to be set: `MEETUP_API_KEY` and `MEETUP_EVENT_SOURCES`. Optionally can set a `RAKE_EVENTS_OWNER_ID` variable as well.

`MEETUP_API_KEY=abcabc123123abcabc123123` - API key from Meetup.
`RAKE_EVENTS_OWNER_ID=1` - id of user that will become the owner of the auto-created events
`MEETUP_EVENT_SOURCES=openwichita,devict,makeict,wwcwichita,etc` - comma separated list of URL slugs for meetup groups to pull from.

Issue #40 -- partially at least
