### PR TITLE
Adds "supports markdown icon" to several fields

### DIFF
--- a/app/views/shared/_person_edit_form.html.erb
+++ b/app/views/shared/_person_edit_form.html.erb
@@ -91,7 +91,7 @@
 <div class="form-group">
     <%= f.label :bio, :class => "sr-only" %>
     <div class="input-group">
-      <div class="input-group-addon">Bio <span class="glyphicon glyphicon-question-sign" data-toggle="tooltip" data-placement="top" title="Feel free to use >Markdown to add panache to your bio."></span></div>
+      <div class="input-group-addon">Bio <%= render 'shared/supports_markdown_icon', title: "Feel free to use >Markdown to add panache to your bio." %></div>
       <%= f.text_area :bio, autofocus: true, :class => "form-control", :style => "height:8em" %>
     </div>
 </div>

--- a/app/views/shared/_supports_markdown_icon.html.erb
+++ b/app/views/shared/_supports_markdown_icon.html.erb
@@ -1,0 +1,2 @@
+<% title = "Powered by Markdown" unless local_assigns.key?(:title) %>
+<span class="glyphicon glyphicon-question-sign" data-toggle="tooltip" data-placement="top" title="<%= title %>">

--- a/app/views/topics/_form.html.erb
+++ b/app/views/topics/_form.html.erb
@@ -9,7 +9,7 @@
 <div class="form-group">
     <%= f.label :content, :class => "sr-only" %>
     <div class="input-group">
-        <div class="input-group-addon">Content</div>
+        <div class="input-group-addon">Content <%= render 'shared/supports_markdown_icon' %></span></div>
         <%= f.text_area :content, :class => "form-control" %>
     </div>
 </div>

--- a/app/views/topics/_form.html.erb
+++ b/app/views/topics/_form.html.erb
@@ -9,7 +9,7 @@
 <div class="form-group">
     <%= f.label :content, :class => "sr-only" %>
     <div class="input-group">
-        <div class="input-group-addon">Content <%= render 'shared/supports_markdown_icon' %></span></div>
+        <div class="input-group-addon">Content <%= render 'shared/supports_markdown_icon' %></div>
         <%= f.text_area :content, :class => "form-control" %>
     </div>
 </div>


### PR DESCRIPTION
![untitled](https://cloud.githubusercontent.com/assets/2501554/19571525/ba18b928-96fe-11e6-816c-8a62fef77d57.png)

Fixes #75 

Note that because the "Topic" model is used as a base for Event, News, as well as Resource it's only necessary to modify this one form.
