### PR TITLE
Implement GitHub-like user matching

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ gem 'select2-rails'
 gem 'sendgrid', '~> 1.2.0'
 gem 'carrierwave'
 gem 'mini_magick'
+gem 'jquery-atwho-rails'
 
 group :development, :test do
   gem 'spring'
@@ -59,6 +60,7 @@ group :development, :test do
   gem 'rspec-rails'
   gem 'rspec-collection_matchers'
   gem 'rspec-nc'
+  gem 'rspec-json_expectations'
   gem 'minitest'
   gem 'capybara'
   gem 'formulaic'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,6 +143,7 @@ GEM
       has_scope (~> 0.6.0.rc)
       railties (>= 3.2, < 4.2)
       responders (~> 1.0)
+    jquery-atwho-rails (1.3.2)
     jquery-rails (3.1.2)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
@@ -259,6 +260,7 @@ GEM
     rspec-expectations (3.1.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.1.0)
+    rspec-json_expectations (1.4.0)
     rspec-mocks (3.1.3)
       rspec-support (~> 3.1.0)
     rspec-nc (0.2.0)
@@ -344,6 +346,7 @@ DEPENDENCIES
   friendly_id (~> 5.1.0)
   fuubar
   gravatar_image_tag
+  jquery-atwho-rails
   jquery-rails
   letter_opener
   meetup_client
@@ -362,6 +365,7 @@ DEPENDENCIES
   redcarpet
   rspec
   rspec-collection_matchers
+  rspec-json_expectations
   rspec-nc
   rspec-rails
   rubocop

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,6 +12,7 @@
 //
 //= require jquery
 //= require jquery_ujs
+//= require jquery.atwho
 //= require bootstrap-sprockets
 //= require owl.carousel
 //= require select2
@@ -27,4 +28,10 @@ $(function () {
   $('input.date-time-picker').datetimepicker();
 
 
+  $('.at-who').atwho({
+    at: "@",
+    data: '/at_who',
+    displayTpl: "<li>${slug} <small>${full_name}</small></li>",
+    searchKey: 'slug',
+  });
 });

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -32,6 +32,7 @@ $(function () {
     at: "@",
     data: '/at_who',
     displayTpl: "<li>${slug} <small>${full_name}</small></li>",
+    insertTpl: "${atwho-at}${slug}",
     searchKey: 'slug',
   });
 });

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -16,6 +16,7 @@
  *= require select2
  *= require select2-bootstrap
  *= require bootstrap-datetimepicker
+ *= require jquery.atwho
  */
 
 @import "bootstrap-sprockets";

--- a/app/controllers/at_who_controller.rb
+++ b/app/controllers/at_who_controller.rb
@@ -1,0 +1,16 @@
+class AtWhoController < ApplicationController
+  def index
+    render json: serialized_people
+  end
+
+  private
+
+  def serialized_people
+    Person.all.map do |profile|
+      {
+        slug: profile.slug,
+        full_name: profile.full_name,
+      }
+    end
+  end
+end

--- a/app/controllers/at_who_controller.rb
+++ b/app/controllers/at_who_controller.rb
@@ -6,11 +6,13 @@ class AtWhoController < ApplicationController
   private
 
   def serialized_people
-    Person.all.map do |profile|
-      {
-        slug: profile.slug,
-        full_name: profile.full_name,
-      }
+    [].tap do |collection|
+      Person.find_each do |person|
+        collection << {
+          slug: person.slug,
+          full_name: person.full_name,
+        }
+      end
     end
   end
 end

--- a/app/views/topics/_form.html.erb
+++ b/app/views/topics/_form.html.erb
@@ -10,7 +10,7 @@
     <%= f.label :content, :class => "sr-only" %>
     <div class="input-group">
         <div class="input-group-addon">Content</div>
-        <%= f.text_area :content, :class => "form-control" %>
+        <%= f.text_area :content, :class => "form-control at-who" %>
     </div>
 </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
   resources :resources
   resources :news
   resources :events
+  resources :at_who
 
   resources :people do
     collection do

--- a/spec/controllers/at_who_controller_spec.rb
+++ b/spec/controllers/at_who_controller_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe AtWhoController, type: :controller do
+  render_views
+
+  describe ".index" do
+    it "returns a list of profiles" do
+      create :person, first_name: 'Alice', last_name: 'Aaronson'
+      create :person, first_name: 'Bob', last_name: 'Brown'
+
+      get :index
+
+      expect(response.body).to include_unordered_json [
+        {
+          slug: 'alice-aaronson',
+          full_name: 'Alice Aaronson',
+        },
+        {
+          slug: 'bob-brown',
+          full_name: 'Bob Brown',
+        }
+      ]
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@ ENV["RAILS_ENV"] ||= 'test'
 require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'
 require 'rspec/collection_matchers'
+require 'rspec/json_expectations'
 require 'capybara/rspec'
 require 'factory_girl_rails'
 


### PR DESCRIPTION
![untitled](https://cloud.githubusercontent.com/assets/2501554/19572686/9e4dff82-9703-11e6-9b3f-7f1c5d0c2695.png)

Fixes #76

You should be able to use the class `at-who` for any input field that you want to add at-who support for. This PR adds it for the topic form.
