### PR TITLE
Overrides RSpec's controller spec generator

### DIFF
--- a/lib/templates/rspec/controller/controller_spec.rb
+++ b/lib/templates/rspec/controller/controller_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+<% module_namespacing do -%>
+describe <%= class_name %>Controller, type: :controller do
+  render_views
+
+end
+
+<% end -%>


### PR DESCRIPTION
When implementing #79, I noticed that `bin/rails g controller` creates a spec file that isn't terribly useful. This PR attempts to replace with a version that is more helpful.

See https://github.com/rspec/rspec-rails/issues/818 for more information with regards to overriding template files in this fashion.
