### PR TITLE
Social sharing image fix

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,7 +20,7 @@
     <meta property="og:url" content="<%= request.original_url %>" />
     <meta property="og:title" content="<%= yield_meta_tag(:og_title, "#{yield(:title) + ' | ' if yield(:title).presence}Startup Wichita") %>" />
     <meta property="og:description" content="<%= yield_meta_tag(:og_description, "Startup Wichita :: The online connecting point of Wichita's Startup &amp; Tech communities.") %>" />
-    <meta property="og:image" content="<%= yield_meta_tag(:og_image, image_url('assets/tophandlogo-02.png')) %>" />
+    <meta property="og:image" content="<%= yield_meta_tag(:og_image, image_url('tophandlogo-02.png')) %>" />
     <meta property="og:image:height" content="<%= yield_meta_tag(:og_image_height, '213') %>" />
     <meta property="og:image:width" content="<%= yield_meta_tag(:og_image_width, '81') %>" />
 
@@ -30,7 +30,7 @@
     <meta name="twitter:url" content="<%= request.original_url %>" />
     <meta name="twitter:title" content="<%= yield_meta_tag(:twitter_title, "#{yield(:title) + ' | ' if yield(:title).presence}Startup Wichita") %>" />
     <meta name="twitter:description" content="<%= yield_meta_tag(:twitter_description, "Startup Wichita :: The online connecting point of Wichita's Startup &amp; Tech communities.") %>" />
-    <meta name="twitter:image" content="<%= yield_meta_tag(:twitter_image, image_url('assets/tophandlogo-02.png')) %>" />
+    <meta name="twitter:image" content="<%= yield_meta_tag(:twitter_image, image_url('tophandlogo-02.png')) %>" />
 
 
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.0/css/bootstrap.min.css">


### PR DESCRIPTION
I saw that the images still weren't pulling correctly. It looks like image_url wasn't linking to the version with the digest on the end of the file name. I believe this should fix that problem. 