### PR TITLE
Use postgres for local dev, via docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ruby:2.2.0
 
 RUN apt-get update -qq \
     && apt-get install -y --no-install-recommends \
-       nodejs libpq-dev build-essential sqlite3
+       nodejs libpq-dev build-essential postgresql-client
 
 RUN mkdir /app
 WORKDIR /app

--- a/config/database.yml
+++ b/config/database.yml
@@ -5,21 +5,24 @@
 #   gem 'sqlite3'
 #
 default: &default
-  adapter: sqlite3
+  adapter: postgresql
+  encoding: unicode
+  host: postgres
+  user: postgres
   pool: 5
   timeout: 5000
 
 development:
   <<: *default
-  database: db/development.sqlite3
+  database: startupwichita_development
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: db/test.sqlite3
+  database: startupwichita_test
 
 production:
   <<: *default
-  database: db/production.sqlite3
+  database: startupwichita_production

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,6 +13,9 @@
 
 ActiveRecord::Schema.define(version: 20171009191656) do
 
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
   create_table "events", force: true do |t|
     t.datetime "starts_at"
     t.datetime "ends_at"
@@ -35,10 +38,10 @@ ActiveRecord::Schema.define(version: 20171009191656) do
     t.datetime "created_at"
   end
 
-  add_index "friendly_id_slugs", ["slug", "sluggable_type", "scope"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type_and_scope", unique: true
-  add_index "friendly_id_slugs", ["slug", "sluggable_type"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type"
-  add_index "friendly_id_slugs", ["sluggable_id"], name: "index_friendly_id_slugs_on_sluggable_id"
-  add_index "friendly_id_slugs", ["sluggable_type"], name: "index_friendly_id_slugs_on_sluggable_type"
+  add_index "friendly_id_slugs", ["slug", "sluggable_type", "scope"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type_and_scope", unique: true, using: :btree
+  add_index "friendly_id_slugs", ["slug", "sluggable_type"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type", using: :btree
+  add_index "friendly_id_slugs", ["sluggable_id"], name: "index_friendly_id_slugs_on_sluggable_id", using: :btree
+  add_index "friendly_id_slugs", ["sluggable_type"], name: "index_friendly_id_slugs_on_sluggable_type", using: :btree
 
   create_table "indications", force: true do |t|
     t.integer  "questionable_id"
@@ -82,10 +85,10 @@ ActiveRecord::Schema.define(version: 20171009191656) do
     t.integer  "profile_score",       default: 0,     null: false
   end
 
-  add_index "people", ["featured"], name: "index_people_on_featured"
-  add_index "people", ["profile_score"], name: "index_people_on_profile_score"
-  add_index "people", ["slug"], name: "index_people_on_slug", unique: true
-  add_index "people", ["user_id"], name: "index_people_on_user_id"
+  add_index "people", ["featured"], name: "index_people_on_featured", using: :btree
+  add_index "people", ["profile_score"], name: "index_people_on_profile_score", using: :btree
+  add_index "people", ["slug"], name: "index_people_on_slug", unique: true, using: :btree
+  add_index "people", ["user_id"], name: "index_people_on_user_id", using: :btree
 
   create_table "person_emails", force: true do |t|
     t.integer  "person_id"
@@ -98,7 +101,7 @@ ActiveRecord::Schema.define(version: 20171009191656) do
     t.datetime "updated_at"
   end
 
-  add_index "person_emails", ["person_id"], name: "index_person_emails_on_person_id"
+  add_index "person_emails", ["person_id"], name: "index_person_emails_on_person_id", using: :btree
 
   create_table "person_roles", force: true do |t|
     t.string   "name"
@@ -119,21 +122,21 @@ ActiveRecord::Schema.define(version: 20171009191656) do
     t.datetime "created_at"
   end
 
-  add_index "taggings", ["context"], name: "index_taggings_on_context"
-  add_index "taggings", ["tag_id", "taggable_id", "taggable_type", "context", "tagger_id", "tagger_type"], name: "taggings_idx", unique: true
-  add_index "taggings", ["taggable_id", "taggable_type", "context"], name: "index_taggings_on_taggable_id_and_taggable_type_and_context"
+  add_index "taggings", ["context"], name: "index_taggings_on_context", using: :btree
+  add_index "taggings", ["tag_id", "taggable_id", "taggable_type", "context", "tagger_id", "tagger_type"], name: "taggings_idx", unique: true, using: :btree
+  add_index "taggings", ["taggable_id", "taggable_type", "context"], name: "index_taggings_on_taggable_id_and_taggable_type_and_context", using: :btree
 
   create_table "tags", force: true do |t|
     t.string  "name"
     t.integer "taggings_count", default: 0
   end
 
-  add_index "tags", ["name"], name: "index_tags_on_name", unique: true
+  add_index "tags", ["name"], name: "index_tags_on_name", unique: true, using: :btree
 
   create_table "topics", force: true do |t|
     t.integer  "user_id"
     t.string   "title"
-    t.text     "content",      limit: 255
+    t.text     "content"
     t.string   "url"
     t.boolean  "spam"
     t.datetime "created_at"
@@ -160,9 +163,9 @@ ActiveRecord::Schema.define(version: 20171009191656) do
     t.string   "uid"
   end
 
-  add_index "users", ["email"], name: "index_users_on_email", unique: true
-  add_index "users", ["provider"], name: "index_users_on_provider"
-  add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
-  add_index "users", ["uid"], name: "index_users_on_uid"
+  add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
+  add_index "users", ["provider"], name: "index_users_on_provider", using: :btree
+  add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
+  add_index "users", ["uid"], name: "index_users_on_uid", using: :btree
 
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,4 +5,8 @@ app:
     - "3000:3000"
   volumes:
     - .:/app
+  links:
+    - postgres:postgres
+postgres:
+  image: postgres
 


### PR DESCRIPTION
So we can easily import dumps from production, and to generally have a local environment more closely resembling production.

Hopefully this doesn't interrupt anyone's local dev environments too much currently. You can always change the `database.yml` file back to sqlite.