### PR TITLE
Fix code formatting in Markdown

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ Take a look at our open issues on the [GitHub Issues page](https://github.com/St
  ### Submitting a pull request via Git command line
  1. Fork the project by clicking “Fork” in the top right corner of StartupWichita/startupwichita.com.
  2. Clone the repository locally <br>
- ```ruby git clone https://github.com/StartupWichita/startupwichita.com.git ```
- 3. Create a new, descriptively named branch to contain your change <br> ``` ruby git checkout -b name_of_your_branch ```
- 4. Push the branch up <br> ```ruby git push origin name_of_your_branch ```
+ `git clone https://github.com/StartupWichita/startupwichita.com.git`
+ 3. Create a new, descriptively named branch to contain your change <br> `git checkout -b name_of_your_branch`
+ 4. Push the branch up <br> `git push origin name_of_your_branch`
  5. Create a pull request by visiting https://github.com/your-username/startupwichita.com and following the instructions at the top of the screen.

--- a/README.md
+++ b/README.md
@@ -19,13 +19,15 @@ Please report any problems you might encounter by [creating an Issue](https://gi
 ## Installation and Setup
 
 Clone the repo and `cd` into the directory.
+
 ```ruby
 git clone https://github.com/StartupWichita/startupwichita.com.git
 cd startupwichita.com
 ```
-Then run ```ruby bundle install ```<br>
-Run the mirgations ``` ruby rake db:migrate ```<br>
-Start server ``` ruby rails s ```
+
+Then run `bundle install`
+Run the mirgations `rake db:migrate`
+Start server `rails s`
 
 **We use sqlite3 as database. Data seeding is also included in the migrations.**
 
@@ -59,7 +61,7 @@ To run commands in the context of the app, use: `docker-compose run app <your cm
 
  ### Submitting a pull request via Git command line
  1. Fork the project by clicking “Fork” in the top right corner of StartupWichita/startupwichita.com.
- 2. Clone the repository locally ```ruby git clone https://github.com/StartupWichita/startupwichita.com.git```
- 3. Create a new, descriptively named branch to contain your change <br> ``` ruby git checkout -b name_of_your_branch ```
- 4. Push the branch up ```ruby git push origin name_of_your_branch ```
+ 2. Clone the repository locally `git clone https://github.com/StartupWichita/startupwichita.com.git`
+ 3. Create a new, descriptively named branch to contain your change <br> `git checkout -b name_of_your_branch`
+ 4. Push the branch up `git push origin name_of_your_branch`
  5. Create a pull request by visiting https://github.com/your-username/startupwichita.com and following the instructions at the top of the screen.


### PR DESCRIPTION
This is a small update to the formatting of command-line steps in the readme and contributing doc. They had extra "ruby" in them, I think because the triple-backtick followed by a language name only works for multi-line blocks in GitHub Markdown. Since they were one-line commands anyway, I just switched to the single-backtick code format.

Before:

<img width="486" alt="startupwichita_startupwichita_com__a_community_site_for_bringing_connection_and_awareness_to_the_tech_and_startup_communities_in_wichita" src="https://user-images.githubusercontent.com/82317/31579720-c453aab0-b101-11e7-960a-9fdff3227442.png">

After:

<img width="488" alt="startupwichita_com_readme_md_at_8844838e7e1bfd6aa9ae85b62554467cc4d17da6_ _cheshire137_startupwichita_com" src="https://user-images.githubusercontent.com/82317/31579718-b3e2d6a6-b101-11e7-8f0f-a05be5c4ca46.png">
