### PR TITLE
Meetup events import

### DIFF
--- a/lib/tasks/pull_events_from_meetup.rake
+++ b/lib/tasks/pull_events_from_meetup.rake
@@ -44,7 +44,7 @@ namespace :events do
 
     def get_and_load_events(event_sources)
       meetup_api = MeetupApi.new
-      two_months_from_now = (Time.now + (60*24*60*60)).to_i
+      two_months_from_now = (Time.now + 2.months).to_i
 
       event_sources.each do |source|
         response = meetup_api.events(

--- a/lib/tasks/pull_events_from_meetup.rake
+++ b/lib/tasks/pull_events_from_meetup.rake
@@ -44,7 +44,7 @@ namespace :events do
 
     def get_and_load_events(event_sources)
       meetup_api = MeetupApi.new
-      two_months_from_now = (Time.now + (60*24*60*60)).to_i * 1000
+      two_months_from_now = (Time.now + (60*24*60*60)).to_i
 
       event_sources.each do |source|
         response = meetup_api.events(


### PR DESCRIPTION
Issue: https://github.com/StartupWichita/startupwichita.com/issues/118

The year for events being imported was incorrectly being set to the year 49000 something because we were multiplying the timestamp by 1000 for some reason.

I removed the multiplication that was causing the problem, and refactored the code using `active_support/cor_ext` helper methods to make it more readable.